### PR TITLE
Add cylinder shape and 4 audit scenes with CLI scene selection

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,17 +2,62 @@ use std::env;
 
 pub struct Config {
     pub num_frames: usize,
+    pub scene: usize,
 }
 
 impl Config {
     pub fn from_args() -> Self {
         let args: Vec<String> = env::args().collect();
-        let num_frames = if args.len() > 1 {
-            args[1].parse().unwrap_or(20)
-        } else {
-            60 // Default number of frames
-        };
-        Self { num_frames }
+        
+        let mut num_frames = 1; // Default: 1 frame
+        let mut scene = 0; // Default: scene 0 (random_scene)
+        
+        let mut i = 1;
+        while i < args.len() {
+            match args[i].as_str() {
+                "--scene" | "-s" => {
+                    if i + 1 < args.len() {
+                        scene = args[i + 1].parse().unwrap_or(0);
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                "--frames" | "-f" => {
+                    if i + 1 < args.len() {
+                        num_frames = args[i + 1].parse().unwrap_or(1);
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                _ => {
+                    // Try to parse as number (for backward compatibility)
+                    if let Ok(n) = args[i].parse::<usize>() {
+                        num_frames = n;
+                    }
+                    i += 1;
+                }
+            }
+        }
+        
+        Self { num_frames, scene }
+    }
+    
+    pub fn print_usage() {
+        eprintln!("Usage: cargo run -- [OPTIONS]");
+        eprintln!("   or: ./target/debug/ray-trace [OPTIONS]");
+        eprintln!("");
+        eprintln!("Options:");
+        eprintln!("  --scene, -s <N>    Select scene (0=random, 1=sphere, 2=plane+cube, 3=all objects, 4=all objects alt camera)");
+        eprintln!("  --frames, -f <N>   Number of frames to render (default: 1)");
+        eprintln!("");
+        eprintln!("Examples:");
+        eprintln!("  cargo run -- --scene 1              # Render scene 1 (sphere)");
+        eprintln!("  cargo run -- --scene 2 --frames 1   # Render scene 2, 1 frame");
+        eprintln!("  cargo run -- 1                     # Render default scene, 1 frame (backward compatible)");
+        eprintln!("");
+        eprintln!("  ./target/debug/ray-trace --scene 1  # After building, run directly");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@ pub mod ppm;
 
 pub use math::{Vec3, Point3, Ray};
 pub use core::{Color, Camera, PointLight, Hittable, HitRecord, HittableList};
-pub use shapes::{Sphere, Plane, Cuboid};
+pub use shapes::{Sphere, Plane, Cuboid, Cylinder};
 pub use scene::render::ray_color;
-pub use scenes::random_scene;
+pub use scenes::{random_scene, scene_sphere, scene_plane_cube, scene_all_objects, scene_all_objects_alt_camera};
 pub use cli::Config;
 pub use ppm::write_color;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,41 @@
 use ray_trace::*;
+use ray_trace::scenes::{random_scene, scene_sphere, scene_plane_cube, scene_all_objects, scene_all_objects_alt_camera};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
 fn main() {
-    // Image
-    const ASPECT_RATIO: f64 = 3.0 / 2.0;
-    const IMAGE_WIDTH: i32 = 400;
-    const IMAGE_HEIGHT: i32 = (IMAGE_WIDTH as f64 / ASPECT_RATIO) as i32;
+    // Image - 800x600 as required for audit
+    const IMAGE_WIDTH: i32 = 800;
+    const IMAGE_HEIGHT: i32 = 600;
+    const ASPECT_RATIO: f64 = IMAGE_WIDTH as f64 / IMAGE_HEIGHT as f64;
     const SAMPLES_PER_PIXEL: i32 = 200;
     const MAX_DEPTH: i32 = 100;
 
-    // Animation
-    const ROTATION_DEGREES: f64 = 360.0; // Full 360-degree rotation
-
-    // Get number of frames from command-line argument
+    // Get configuration from command-line arguments
     let config = Config::from_args();
     let num_frames = config.num_frames;
+    let scene_num = config.scene;
 
-    // World
-    let world = random_scene();
+    // Select scene based on CLI argument
+    let world = match scene_num {
+        0 => random_scene(),
+        1 => scene_sphere(),
+        2 => scene_plane_cube(),
+        3 => scene_all_objects(),
+        4 => scene_all_objects_alt_camera(),
+        _ => {
+            eprintln!("Unknown scene number: {}. Using default scene 0.", scene_num);
+            random_scene()
+        }
+    };
 
-    let intensity = 0.75;
+    // Adjust brightness based on scene (scene 2 needs lower brightness)
+    let intensity = if scene_num == 2 {
+        0.3  // Lower brightness for scene 2 (plane + cube)
+    } else {
+        0.75 // Normal brightness for other scenes
+    };
+
     let lights = vec![
         PointLight::new(Point3::new(0.0, 5.0, 4.0), Color::new(1.0, 0.85, 0.6), intensity), // overhead lamp
     ];
@@ -28,28 +43,67 @@ fn main() {
     // --- Render Loop for Video ---
     for frame in 0..num_frames {
         // --- Calculate Camera Position for this frame ---
-        let lookat = Point3::new(0.85, 0.2, 1.35);
+        // Different camera positions for different scenes
+        let (lookat, lookfrom) = match scene_num {
+            1 => {
+                // Scene 1: Sphere - camera looking at sphere
+                let lookat = Point3::new(0.0, 1.0, 0.0);
+                let lookfrom = Point3::new(3.0, 2.0, 3.0);
+                (lookat, lookfrom)
+            }
+            2 => {
+                // Scene 2: Plane + Cube - camera looking at cube
+                let lookat = Point3::new(0.0, 0.5, 0.0);
+                let lookfrom = Point3::new(5.0, 5.0, 5.0);
+                (lookat, lookfrom)
+            }
+            3 => {
+                // Scene 3: All objects - camera looking at center, хороший обзор всех объектов
+                let lookat = Point3::new(0.0, 0.6, 0.0);  // Смотрим на центр объектов
+                let lookfrom = Point3::new(4.0, 2.5, 4.0); // Камера спереди-сбоку, выше
+                (lookat, lookfrom)
+            }
+            4 => {
+                // Scene 4: All objects - different camera angle, с другой стороны
+                let lookat = Point3::new(0.0, 0.6, 0.0);   // Тот же центр
+                let lookfrom = Point3::new(-4.0, 2.5, 4.0); // Камера с другой стороны
+                (lookat, lookfrom)
+            }
+            _ => {
+                // Default: original camera setup
+                let lookat = Point3::new(0.85, 0.2, 1.35);
+                let radius = 6.5;
+                let start_angle_rad = 0.46;
+                let angle_step = if num_frames > 1 {
+                    crate::core::common::degrees_to_radians(360.0) / num_frames as f64
+                } else {
+                    0.0
+                };
+                let current_angle = start_angle_rad + frame as f64 * angle_step;
+                let lookfrom = Point3::new(
+                    lookat.x() + radius * current_angle.cos(),
+                    3.5,
+                    lookat.z() + radius * current_angle.sin()
+                );
+                (lookat, lookfrom)
+            }
+        };
+
         let vup = Point3::new(0.0, 1.0, 0.0);
         let dist_to_focus = 6.0;
-        let aperture = 0.02; //0.0 pinhole 0.05 noticably blur
+        let aperture = 0.02;
 
-        // Orbit parameters
-        let radius = 6.5; // Distance from lookat point in the XZ plane
-        let start_angle_rad = 0.46; // Initial angle to match the original view
-        let angle_step = crate::core::common::degrees_to_radians(ROTATION_DEGREES) / num_frames as f64;
-        let current_angle = start_angle_rad + frame as f64 * angle_step;
-
-        let lookfrom = Point3::new(
-            lookat.x() + radius * current_angle.cos(),
-            3.5, // Keep camera height constant
-            lookat.z() + radius * current_angle.sin()
-        );
+        // Adjust FOV based on scene for better visibility
+        let vfov = match scene_num {
+            3 | 4 => 30.0,  // Wider FOV for scenes with all objects
+            _ => 20.0,      // Default FOV
+        };
 
         let cam = Camera::new(
             lookfrom,
             lookat,
             vup,
-            20.0,
+            vfov,
             ASPECT_RATIO,
             aperture,
             dist_to_focus,
@@ -59,7 +113,7 @@ fn main() {
         eprintln!("DEBUG: IMAGE_WIDTH = {}, IMAGE_HEIGHT = {}, lookfrom_y = {}", IMAGE_WIDTH, IMAGE_HEIGHT, lookfrom.y());
 
         // --- Render a single frame ---
-        let filename = format!("output/frame_{:03}.ppm", frame);
+        let filename = format!("output/scene{}_frame_{:03}.ppm", scene_num, frame);
         eprintln!("\nRendering frame {}/{} to {}", frame + 1, num_frames, filename);
         let file = File::create(&filename).expect("Failed to create file.");
         let mut writer = BufWriter::new(file);

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use crate::core::{HittableList, Color, common};
-use crate::core::material::{Material, NumberType, LambertianNoise, Metal, Striped};
-use crate::shapes::{Sphere, Plane};
+use crate::core::material::{Material, NumberType, LambertianNoise, Metal, Striped, Lambertian};
+use crate::shapes::{Sphere, Plane, Cylinder, Cuboid};
 use crate::math::vec3::{Point3, Vec3};
 
 pub fn random_scene() -> HittableList {
@@ -59,5 +59,100 @@ pub fn random_scene() -> HittableList {
         }
     }
     world
+}
+
+// ========== AUDIT SCENES ==========
+
+/// Scene 1: Only a sphere
+pub fn scene_sphere() -> HittableList {
+    let mut world = HittableList::new();
+
+    // Ground plane
+    let ground_material = Rc::new(Lambertian::new(Color::new(0.5, 0.5, 0.5)));
+    world.add(Box::new(Plane::new(
+        Point3::new(0.0, 0.0, 0.0),
+        Vec3::new(0.0, 1.0, 0.0),
+        ground_material,
+    )));
+
+    // Single sphere
+    let sphere_material = Rc::new(Lambertian::new(Color::new(0.7, 0.3, 0.3))); // Red sphere
+    world.add(Box::new(Sphere::new(
+        Point3::new(0.0, 1.0, 0.0),  // Center above ground
+        0.5,                          // Radius
+        sphere_material,
+    )));
+
+    world
+}
+
+/// Scene 2: Plane + Cube with lower brightness (brightness controlled in main.rs)
+pub fn scene_plane_cube() -> HittableList {
+    let mut world = HittableList::new();
+
+    // Ground plane
+    let ground_material = Rc::new(Lambertian::new(Color::new(0.5, 0.5, 0.5)));
+    world.add(Box::new(Plane::new(
+        Point3::new(0.0, 0.0, 0.0),
+        Vec3::new(0.0, 1.0, 0.0),
+        ground_material,
+    )));
+
+    // Cube
+    let cube_material = Rc::new(Lambertian::new(Color::new(0.4, 0.6, 0.8))); // Blue cube
+    world.add(Box::new(Cuboid::new(
+        Point3::new(-0.5, 0.0, -0.5),  // Min corner
+        Point3::new(0.5, 1.0, 0.5),    // Max corner
+        cube_material,
+    )));
+
+    world
+}
+
+/// Scene 3: All objects (sphere, cube, cylinder, plane)
+pub fn scene_all_objects() -> HittableList {
+    let mut world = HittableList::new();
+
+    // Ground plane
+    let ground_material = Rc::new(Lambertian::new(Color::new(0.5, 0.5, 0.5)));
+    world.add(Box::new(Plane::new(
+        Point3::new(0.0, 0.0, 0.0),
+        Vec3::new(0.0, 1.0, 0.0),
+        ground_material,
+    )));
+
+    // Sphere - слева, ближе к камере
+    let sphere_material = Rc::new(Lambertian::new(Color::new(0.8, 0.2, 0.2))); // Red
+    world.add(Box::new(Sphere::new(
+        Point3::new(-1.5, 0.6, 0.0),  // Выше и ближе
+        0.6,                           // Больше размер
+        sphere_material,
+    )));
+
+    // Cube - в центре
+    let cube_material = Rc::new(Lambertian::new(Color::new(0.2, 0.2, 0.8))); // Blue
+    world.add(Box::new(Cuboid::new(
+        Point3::new(-0.6, 0.0, -0.6),  // Центр смещен немного назад
+        Point3::new(0.6, 1.2, 0.6),    // Выше куб
+        cube_material,
+    )));
+
+    // Cylinder - справа, дальше
+    let cylinder_material = Rc::new(Lambertian::new(Color::new(0.2, 0.8, 0.2))); // Green
+    world.add(Box::new(Cylinder::new(
+        Point3::new(1.5, 0.0, 0.0),    // Справа
+        Vec3::new(0.0, 1.0, 0.0),
+        0.6,                            // Больше радиус
+        1.8,                            // Выше
+        cylinder_material,
+    )));
+
+    world
+}
+
+/// Scene 4: Same as scene 3, but camera position will be different (handled in main.rs)
+pub fn scene_all_objects_alt_camera() -> HittableList {
+    // Same scene as scene_all_objects, camera position differs in main.rs
+    scene_all_objects()
 }
 

--- a/src/shapes/cylinder.rs
+++ b/src/shapes/cylinder.rs
@@ -1,0 +1,201 @@
+use std::rc::Rc;
+
+use crate::core::hittable::{HitRecord, Hittable};
+use crate::core::material::Material;
+use crate::math::ray::Ray;
+use crate::math::vec3::{Point3, Vec3};
+
+pub struct Cylinder {
+    base: Point3,      // Center of the bottom circle
+    axis: Vec3,        // Direction vector (pointing from base to top)
+    radius: f64,
+    height: f64,
+    mat: Rc<dyn Material>,
+}
+
+impl Cylinder {
+    pub fn new(base: Point3, axis: Vec3, radius: f64, height: f64, mat: Rc<dyn Material>) -> Self {
+        Self {
+            base,
+            axis: axis.unit_vector(),
+            radius,
+            height,
+            mat,
+        }
+    }
+
+    /// Check if a point is within the cylinder's height bounds
+    fn is_within_height(&self, point: Point3) -> bool {
+        let base_to_point = point - self.base;
+        let projection = base_to_point.dot(&self.axis);
+        projection >= 0.0 && projection <= self.height
+    }
+
+    /// Get the normal at a given point on the cylinder
+    fn get_normal(&self, point: Point3) -> Vec3 {
+        let base_to_point = point - self.base;
+        let projection = base_to_point.dot(&self.axis);
+        
+        const EPS: f64 = 1e-4;
+        
+        // Check if we hit the bottom cap
+        if projection.abs() < EPS {
+            return -self.axis;
+        }
+        
+        // Check if we hit the top cap
+        if (projection - self.height).abs() < EPS {
+            return self.axis;
+        }
+        
+        // Hit the curved side: normal is perpendicular to axis
+        let axis_point = self.base + projection * self.axis;
+        (point - axis_point).unit_vector()
+    }
+
+    /// Check for intersection with the top and bottom circular caps
+    fn hit_caps(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<(f64, Point3, Vec3)> {
+        let d_dot_axis = r.direction().dot(&self.axis);
+        
+        // If ray is parallel to caps, no intersection
+        if d_dot_axis.abs() < 1e-8 {
+            return None;
+        }
+        
+        let mut closest_t = t_max;
+        let mut hit_found = false;
+        let mut hit_normal = Vec3::default();
+        let mut hit_point = Point3::default();
+        
+        // Check bottom cap
+        let oc_bottom = r.origin() - self.base;
+        let t_bottom = -oc_bottom.dot(&self.axis) / d_dot_axis;
+        
+        if t_bottom >= t_min && t_bottom < closest_t {
+            let point = r.at(t_bottom);
+            let base_to_point = point - self.base;
+            let radial_dist_sq = (base_to_point - base_to_point.dot(&self.axis) * self.axis).length_squared();
+            
+            if radial_dist_sq <= self.radius * self.radius {
+                closest_t = t_bottom;
+                hit_point = point;
+                hit_normal = -self.axis;
+                hit_found = true;
+            }
+        }
+        
+        // Check top cap
+        let top_center = self.base + self.height * self.axis;
+        let oc_top = r.origin() - top_center;
+        let t_top = -oc_top.dot(&self.axis) / d_dot_axis;
+        
+        if t_top >= t_min && t_top < closest_t {
+            let point = r.at(t_top);
+            let top_to_point = point - top_center;
+            let radial_dist_sq = (top_to_point - top_to_point.dot(&self.axis) * self.axis).length_squared();
+            
+            if radial_dist_sq <= self.radius * self.radius {
+                closest_t = t_top;
+                hit_point = point;
+                hit_normal = self.axis;
+                hit_found = true;
+            }
+        }
+        
+        if hit_found {
+            Some((closest_t, hit_point, hit_normal))
+        } else {
+            None
+        }
+    }
+}
+
+impl Hittable for Cylinder {
+    fn hit(&self, r: &Ray, t_min: f64, t_max: f64, rec: &mut HitRecord) -> bool {
+        let oc = r.origin() - self.base;
+        
+        // Project ray direction and origin offset onto the plane perpendicular to axis
+        let d_dot_axis = r.direction().dot(&self.axis);
+        let oc_dot_axis = oc.dot(&self.axis);
+        
+        let d_perp = r.direction() - d_dot_axis * self.axis;
+        let oc_perp = oc - oc_dot_axis * self.axis;
+        
+        // Solve quadratic equation for intersection with infinite cylinder
+        let a = d_perp.dot(&d_perp);
+        
+        // Avoid division by zero
+        if a < 1e-8 {
+            // Ray is parallel to axis, only check caps
+            if let Some((t, point, normal)) = self.hit_caps(r, t_min, t_max) {
+                rec.t = t;
+                rec.p = point;
+                rec.mat = Some(self.mat.clone());
+                rec.set_face_normal(r, normal);
+                return true;
+            }
+            return false;
+        }
+        
+        let b = 2.0 * oc_perp.dot(&d_perp);
+        let c = oc_perp.dot(&oc_perp) - self.radius * self.radius;
+        
+        let discriminant = b * b - 4.0 * a * c;
+        
+        let mut best_t = t_max;
+        let mut hit_found = false;
+        let mut hit_point = Point3::default();
+        let mut hit_normal = Vec3::default();
+        
+        // Check side intersection if discriminant is valid
+        if discriminant >= 0.0 {
+            let sqrt_d = discriminant.sqrt();
+            let mut root = (-b - sqrt_d) / (2.0 * a);
+            
+            // Check first root
+            if root >= t_min && root <= t_max {
+                let point = r.at(root);
+                if self.is_within_height(point) {
+                    best_t = root;
+                    hit_point = point;
+                    hit_normal = self.get_normal(point);
+                    hit_found = true;
+                }
+            }
+            
+            // Check second root if first didn't work or if it's closer
+            root = (-b + sqrt_d) / (2.0 * a);
+            if root >= t_min && root <= t_max && root < best_t {
+                let point = r.at(root);
+                if self.is_within_height(point) {
+                    best_t = root;
+                    hit_point = point;
+                    hit_normal = self.get_normal(point);
+                    hit_found = true;
+                }
+            }
+        }
+        
+        // Check caps and compare with side intersection
+        if let Some((t, point, normal)) = self.hit_caps(r, t_min, t_max) {
+            if t < best_t {
+                best_t = t;
+                hit_point = point;
+                hit_normal = normal;
+                hit_found = true;
+            }
+        }
+        
+        if hit_found {
+            rec.t = best_t;
+            rec.p = hit_point;
+            rec.mat = Some(self.mat.clone());
+            rec.set_face_normal(r, hit_normal);
+            return true;
+        }
+        
+        false
+    }
+}
+
+

--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -1,8 +1,10 @@
 pub mod sphere;
 pub mod plane;
 pub mod cuboid;
+pub mod cylinder;
 
 pub use sphere::Sphere;
 pub use plane::Plane;
 pub use cuboid::Cuboid;
+pub use cylinder::Cylinder;
 


### PR DESCRIPTION
- Add Cylinder shape implementation with proper hit detection for sides and caps
- Create 4 audit scenes: sphere only, plane+cube, all objects, all objects alt camera
- Add CLI scene selection via --scene flag
- Update resolution to 800x600 as required for audit
- Improve camera positioning for better object visibility
- Add proper scene brightness control (lower for scene 2)